### PR TITLE
fix: Adds tests for safe derivation levels and explicitly checks 8*ZL against 2^255  ENG-440

### DIFF
--- a/Sources/bip32-ed25519-swift/bip32-ed25519-swift.swift
+++ b/Sources/bip32-ed25519-swift/bip32-ed25519-swift.swift
@@ -242,7 +242,6 @@ public class Bip32Ed25519 {
         var leftData = Data(left.serialize().reversed())
         var rightData = Data(right.serialize().reversed()).prefix(ED25519_SCALAR_SIZE)
 
-
         // Padding for left
         leftData = Data(repeating: 0, count: ED25519_SCALAR_SIZE - leftData.count) + leftData
 

--- a/Sources/bip32-ed25519-swift/bip32-ed25519-swift.swift
+++ b/Sources/bip32-ed25519-swift/bip32-ed25519-swift.swift
@@ -233,7 +233,7 @@ public class Bip32Ed25519 {
         // left = kl + 8 * trunc28(zl)
         // right = zr + kr mod 2^256
         let left = BigUInt(Data(kl.reversed())) + BigUInt(Data(trunc256MinusGBits(zl: zl, g: g).reversed())) * BigUInt(8)
-        guard left < (BigUInt(1) << 255) else {
+        guard left < (BigUInt(2).power(255)) else {
             throw BigIntException.overflow
         }
         let right = BigUInt(Data(kr.reversed())) + BigUInt(Data(zr.reversed()))

--- a/Sources/bip32-ed25519-swift/bip32-ed25519-swift.swift
+++ b/Sources/bip32-ed25519-swift/bip32-ed25519-swift.swift
@@ -246,9 +246,7 @@ public class Bip32Ed25519 {
         leftData = Data(repeating: 0, count: ED25519_SCALAR_SIZE - leftData.count) + leftData
 
         // Padding for right
-        if rightData.count > ED25519_SCALAR_SIZE {
-            rightData = rightData.subdata(in: 0 ..< ED25519_SCALAR_SIZE)
-        }
+        rightData = rightData.prefix(ED25519_SCALAR_SIZE)
         rightData += Data(repeating: 0, count: ED25519_SCALAR_SIZE - rightData.count)
 
         var result = Data()

--- a/Tests/bip32-ed25519-swiftTests/bip32-ed25519-swiftTests.swift
+++ b/Tests/bip32-ed25519-swiftTests/bip32-ed25519-swiftTests.swift
@@ -271,8 +271,8 @@ final class Bip32Ed25519Tests: XCTestCase {
         class BrokenBip32Ed25519: Bip32Ed25519 {
             // Override the deriveNonHardened method to return a fixed value
             // Specifically, all 1s (0xFF octets)
-            override func deriveNonHardened(kl: Data, cc: Data, index: UInt32) -> (z: Data, childChainCode: Data) {
-                return (Data(repeating: 0xFF, count: ED25519_SCALAR_SIZE * 2), Data((0 ..< CHAIN_CODE_SIZE * 2).map { _ in UInt8.random(in: 0 ... 255) }))
+            override func deriveNonHardened(kl _: Data, cc _: Data, index _: UInt32) -> (z: Data, childChainCode: Data) {
+                (Data(repeating: 0xFF, count: ED25519_SCALAR_SIZE * 2), Data((0 ..< CHAIN_CODE_SIZE * 2).map { _ in UInt8.random(in: 0 ... 255) }))
             }
         }
 

--- a/Tests/bip32-ed25519-swiftTests/bip32-ed25519-swiftTests.swift
+++ b/Tests/bip32-ed25519-swiftTests/bip32-ed25519-swiftTests.swift
@@ -125,7 +125,7 @@ final class Bip32Ed25519Tests: XCTestCase {
         let expectedOutputs = [Data([152, 225, 53, 235, 111, 189, 16, 80, 5, 187, 222, 103, 51, 25, 9, 175, 172, 210, 205, 151, 195, 80, 249, 179, 162, 157, 197, 181, 222, 236, 143, 70, 235, 179, 35, 29, 125, 172, 171, 5, 131, 195, 126, 183, 57, 159, 45, 69, 232, 136, 154, 57, 174, 63, 130, 164, 117, 24, 105, 139, 121, 92, 17, 211, 107, 102, 4, 2, 204, 196, 48, 71, 244, 82, 253, 123, 214, 63, 171, 147, 161, 188, 133, 206, 203, 205, 213, 26, 83, 29, 133, 228, 82, 216, 30, 127]), Data([248, 91, 210, 62, 156, 144, 108, 177, 63, 167, 126, 1, 132, 58, 45, 178, 246, 252, 188, 221, 105, 104, 97, 54, 232, 92, 190, 228, 226, 236, 143, 70, 187, 122, 35, 69, 101, 182, 49, 122, 216, 252, 71, 107, 197, 176, 56, 18, 136, 95, 146, 175, 1, 151, 252, 83, 155, 22, 27, 106, 47, 67, 37, 75, 213, 25, 13, 246, 205, 204, 73, 226, 124, 111, 209, 124, 76, 32, 166, 121, 128, 234, 224, 65, 27, 230, 42, 228, 35, 106, 79, 138, 154, 149, 109, 227])]
 
         for i in 0 ..< indices.count {
-            let output = c!.deriveChildNodePrivate(extendedKey: extendedKeys[i], index: indices[i], g: BIP32DerivationType.Khovratovich)
+            let output = try c!.deriveChildNodePrivate(extendedKey: extendedKeys[i], index: indices[i], g: BIP32DerivationType.Khovratovich)
             XCTAssertEqual(output, expectedOutputs[i])
             XCTAssertEqual(output.count, 96)
         }
@@ -156,11 +156,11 @@ final class Bip32Ed25519Tests: XCTestCase {
         let bip44Path = [UInt32]([2_147_483_692, 2_147_483_931, 2_147_483_648, 0, 0])
         let expectedResultPublic = Data([98, 254, 131, 43, 122, 209, 5, 68, 190, 131, 55, 166, 112, 67, 94, 80, 100, 174, 74, 102, 231, 123, 215, 137, 9, 118, 91, 70, 181, 118, 166, 243])
 
-        let outputPublic = c!.deriveKey(rootKey: rootkey, bip44Path: bip44Path, isPrivate: false, derivationType: BIP32DerivationType.Khovratovich)
+        let outputPublic = try c!.deriveKey(rootKey: rootkey, bip44Path: bip44Path, isPrivate: false, derivationType: BIP32DerivationType.Khovratovich)
         XCTAssertEqual(outputPublic.prefix(32), expectedResultPublic)
 
         let expectedResultPrivate = Data([128, 16, 43, 185, 143, 170, 195, 253, 23, 137, 194, 198, 197, 89, 211, 113, 92, 217, 202, 194, 40, 214, 212, 176, 247, 106, 35, 70, 234, 236, 143, 70, 1, 174, 20, 40, 64, 137, 36, 62, 147, 107, 233, 27, 40, 35, 204, 20, 47, 117, 49, 53, 234, 255, 27, 174, 32, 211, 238, 199, 120, 112, 197, 68, 159, 146, 199, 144, 215, 171, 174, 224, 224, 10, 78, 193, 251, 120, 161, 212, 56, 232, 204, 247, 194, 186, 217, 160, 24, 165, 191, 154, 93, 81, 0, 117])
-        let outputPrivate = c!.deriveKey(rootKey: rootkey, bip44Path: bip44Path, isPrivate: true, derivationType: BIP32DerivationType.Khovratovich)
+        let outputPrivate = try c!.deriveKey(rootKey: rootkey, bip44Path: bip44Path, isPrivate: true, derivationType: BIP32DerivationType.Khovratovich)
         XCTAssertEqual(outputPrivate, expectedResultPrivate)
     }
 
@@ -179,7 +179,7 @@ final class Bip32Ed25519Tests: XCTestCase {
         let derivationTypes: [BIP32DerivationType] = [.Khovratovich, .Peikert]
 
         for derivationType in derivationTypes {
-            let walletRoot = c!.deriveKey(
+            let walletRoot = try c!.deriveKey(
                 rootKey: c!.fromSeed(data),
                 bip44Path: bip44Path,
                 isPrivate: false,
@@ -189,7 +189,7 @@ final class Bip32Ed25519Tests: XCTestCase {
             let numPublicKeysToDerive = 10
             for i in 0 ..< numPublicKeysToDerive {
                 let derivedKey = try c!.deriveChildNodePublic(extendedKey: walletRoot, index: UInt32(i), g: derivationType)
-                let myKey = c!.keyGen(context: context, account: account, change: change, keyIndex: UInt32(i), derivationType: derivationType)
+                let myKey = try c!.keyGen(context: context, account: account, change: change, keyIndex: UInt32(i), derivationType: derivationType)
 
                 XCTAssertEqual(derivedKey.prefix(32), myKey, "The derived key does not match the expected key for derivation type \(derivationType)")
             }
@@ -209,7 +209,7 @@ final class Bip32Ed25519Tests: XCTestCase {
         // hardened change level
         let bip44Path: [UInt32] = [c!.harden(44), c!.harden(283), c!.harden(0), c!.harden(0)]
 
-        let walletRoot = c!.deriveKey(
+        let walletRoot = try c!.deriveKey(
             rootKey: c!.fromSeed(data),
             bip44Path: bip44Path,
             isPrivate: false,
@@ -218,9 +218,17 @@ final class Bip32Ed25519Tests: XCTestCase {
 
         let numPublicKeysToDerive = 10
         for i in 0 ..< numPublicKeysToDerive {
-            let derivedKey = try c!.deriveChildNodePublic(extendedKey: walletRoot, index: UInt32(i), g: BIP32DerivationType.Peikert)
+            let derivedKey = try c!.deriveChildNodePublic(
+                extendedKey: walletRoot,
+                index: UInt32(i),
+                g: BIP32DerivationType.Peikert)
             // Deriving from my own wallet where i DO have private information
-            let myKey = c!.keyGen(context: context, account: account, change: change, keyIndex: UInt32(i), derivationType: BIP32DerivationType.Peikert)
+            let myKey = try c!.keyGen(
+                context: context,
+                account: account,
+                change: change,
+                keyIndex: UInt32(i),
+                derivationType: BIP32DerivationType.Peikert)
 
             // they should NOT match  since the `change` level (as part of BIP44) was hardened
             // derivedKey.prefix(32) ==  public key (excluding chaincode)
@@ -236,7 +244,7 @@ final class Bip32Ed25519Tests: XCTestCase {
 
         let bip44Path: [UInt32] = [c!.harden(44), c!.harden(283), c!.harden(0), 0]
 
-        let walletRoot = c!.deriveKey(
+        let walletRoot = try c!.deriveKey(
             rootKey: c!.fromSeed(data),
             bip44Path: bip44Path,
             isPrivate: false,
@@ -245,6 +253,38 @@ final class Bip32Ed25519Tests: XCTestCase {
 
         // should fail to derive public keys with a hardened index
         XCTAssertThrowsError(try c!.deriveChildNodePublic(extendedKey: walletRoot, index: c!.harden(UInt32(0)), g: BIP32DerivationType.Peikert))
+    }
+
+    func testSafeLevelsOfDerivation() throws {}
+
+    func testDeriveMaxLevelsForKnownSeed() throws {
+        let seed = try Mnemonic.deterministicSeedString(
+            from: "salon zoo engage submit smile frost later decide wing sight chaos renew lizard rely canal coral scene hobby scare step bus leaf tobacco slice")
+        guard let data = Data(hexString: seed) else {
+            return
+        }
+
+        var derivationPath: [UInt32] = [
+            c!.harden(44), c!.harden(283), c!.harden(0), 0, 0] + Array(repeating: 0, count: 19)
+        let derivationType = BIP32DerivationType.Peikert
+
+        _ = try c!.deriveKey(
+            rootKey: c!.fromSeed(data),
+            bip44Path: derivationPath,
+            isPrivate: true,
+            derivationType: derivationType)
+
+        derivationPath += [0]
+
+        XCTAssert(derivationPath.count == 25)
+
+        XCTAssertThrowsError(
+            try c!.deriveKey(
+                rootKey: c!.fromSeed(data),
+                bip44Path: derivationPath,
+                isPrivate: true,
+                derivationType: derivationType),
+                "Expected deriveKey to throw an error")
     }
 
     func testKeyGeneration() throws {
@@ -278,7 +318,7 @@ final class Bip32Ed25519Tests: XCTestCase {
         ]
 
         for (input, expected) in testVectors {
-            let pk = (c?.keyGen(context: input.0, account: input.1, change: input.2, keyIndex: input.3, derivationType: BIP32DerivationType.Khovratovich))!
+            let pk = (try c?.keyGen(context: input.0, account: input.1, change: input.2, keyIndex: input.3, derivationType: BIP32DerivationType.Khovratovich))!
             XCTAssertEqual(pk, expected)
         }
     }
@@ -289,8 +329,8 @@ final class Bip32Ed25519Tests: XCTestCase {
         let prefixEncodedTx = Data(base64Encoded: "VFiJo2FtdM0D6KNmZWXNA+iiZnbOAkeSd6NnZW6sdGVzdG5ldC12MS4womdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4CR5Zfo3JjdsQgYv6DK3rRBUS+gzemcENeUGSuSmbne9eJCXZbRrV2pvOjc25kxCBi/oMretEFRL6DN6ZwQ15QZK5KZud714kJdltGtXam86R0eXBlo3BheQ==")
 
         let bip44Path = (KeyContext.Address, UInt32(0), UInt32(0), UInt32(0))
-        guard let pk = c?.keyGen(context: bip44Path.0, account: bip44Path.1, change: bip44Path.2, keyIndex: bip44Path.3, derivationType: BIP32DerivationType.Khovratovich) else { return }
-        guard let sig = c?.signAlgoTransaction(context: bip44Path.0, account: bip44Path.1, change: bip44Path.2, keyIndex: bip44Path.3, prefixEncodedTx: prefixEncodedTx!, derivationType: BIP32DerivationType.Khovratovich) else { return }
+        guard let pk = try c?.keyGen(context: bip44Path.0, account: bip44Path.1, change: bip44Path.2, keyIndex: bip44Path.3, derivationType: BIP32DerivationType.Khovratovich) else { return }
+        guard let sig = try c?.signAlgoTransaction(context: bip44Path.0, account: bip44Path.1, change: bip44Path.2, keyIndex: bip44Path.3, prefixEncodedTx: prefixEncodedTx!, derivationType: BIP32DerivationType.Khovratovich) else { return }
 
         XCTAssertEqual(c?.verifyWithPublicKey(signature: sig, message: prefixEncodedTx!, publicKey: pk), true)
         XCTAssertEqual(try TestUtils.encodeAddress(bytes: pk), "ML7IGK322ECUJPUDG6THAQ26KBSK4STG4555PCIJOZNUNNLWU3Z3ZFXITA")
@@ -547,7 +587,7 @@ final class Bip32Ed25519Tests: XCTestCase {
         "eyIwIjogMjgsICIxIjogMTAzLCAiMiI6IDI2LCAiMyI6IDIyMiwgIjQiOiA3LCAiNSI6IDg2LCAiNiI6IDU1LCAiNyI6IDk1LCAiOCI6IDE5NywgIjkiOiAxNzksICIxMCI6IDI0OSwgIjExIjogMjUyLCAiMTIiOiAyMzIsICIxMyI6IDI1MiwgIjE0IjogMTc2LCAiMTUiOiAzOSwgIjE2IjogMTEyLCAiMTciOiAxMzEsICIxOCI6IDUyLCAiMTkiOiA2MywgIjIwIjogMjEyLCAiMjEiOiA1OCwiMjIiOiAyMjYsICIyMyI6IDg5LCAiMjQiOiA2NCwgIjI1IjogOTQsICIyNiI6IDIzLCAiMjciOiA5MSwgIjI4IjogMTI4LCAiMjkiOiAxNDMsICIzMCI6IDEyMywgIjMxIjogMjd9",
         "de0020a1301ca13167a1321aa133ccdea13407a13556a13637a1375fa138ccc5a139ccb3a23130ccf9a23131ccfca23132cce8a23133ccfca23134ccb0a2313527a2313670a23137cc83a2313834a231393fa23230ccd4a232313aa23232cce2a2323359a2323440a232355ea2323617a232375ba23238cc80a23239cc8fa233307ba233311b"]
 
-        let pubkey = c?.keyGen(context: KeyContext.Address, account: 0, change: 0, keyIndex: 0, derivationType: BIP32DerivationType.Khovratovich)
+        let pubkey = try c?.keyGen(context: KeyContext.Address, account: 0, change: 0, keyIndex: 0, derivationType: BIP32DerivationType.Khovratovich)
 
         let sig = try c?.signData(context: KeyContext.Address, account: 0, change: 0, keyIndex: 0, data: Data(challengeJSON[0].utf8), metadata: SignMetadata(encoding: Encoding.none, schema: schema), derivationType: BIP32DerivationType.Khovratovich)
         let result = c?.verifyWithPublicKey(signature: sig!, message: Data(challengeJSON[0].utf8), publicKey: pubkey!)
@@ -597,11 +637,11 @@ final class Bip32Ed25519Tests: XCTestCase {
             throw NSError(domain: "Bip32Ed25519ECDHTests", code: 1, userInfo: [NSLocalizedDescriptionKey: "Bip32Ed25519 not initialized"])
         }
 
-        let aliceKey = alice?.keyGen(context: KeyContext.Identity, account: 0, change: 0, keyIndex: 0, derivationType: BIP32DerivationType.Khovratovich)
-        let bobKey = bob?.keyGen(context: KeyContext.Identity, account: 0, change: 0, keyIndex: 0, derivationType: BIP32DerivationType.Khovratovich)
+        let aliceKey = try alice?.keyGen(context: KeyContext.Identity, account: 0, change: 0, keyIndex: 0, derivationType: BIP32DerivationType.Khovratovich)
+        let bobKey = try bob?.keyGen(context: KeyContext.Identity, account: 0, change: 0, keyIndex: 0, derivationType: BIP32DerivationType.Khovratovich)
 
-        let aliceSharedSecret = alice?.ECDH(context: KeyContext.Identity, account: 0, change: 0, keyIndex: 0, otherPartyPub: bobKey!, meFirst: true, derivationType: BIP32DerivationType.Khovratovich)
-        let bobSharedSecret = bob?.ECDH(context: KeyContext.Identity, account: 0, change: 0, keyIndex: 0, otherPartyPub: aliceKey!, meFirst: false, derivationType: BIP32DerivationType.Khovratovich)
+        let aliceSharedSecret = try alice?.ECDH(context: KeyContext.Identity, account: 0, change: 0, keyIndex: 0, otherPartyPub: bobKey!, meFirst: true, derivationType: BIP32DerivationType.Khovratovich)
+        let bobSharedSecret = try bob?.ECDH(context: KeyContext.Identity, account: 0, change: 0, keyIndex: 0, otherPartyPub: aliceKey!, meFirst: false, derivationType: BIP32DerivationType.Khovratovich)
 
         XCTAssertNotEqual(aliceKey, bobKey)
         XCTAssertEqual(aliceSharedSecret, bobSharedSecret)
@@ -609,8 +649,8 @@ final class Bip32Ed25519Tests: XCTestCase {
 
         // Reverse concatenation order
 
-        let aliceSharedSecret2 = alice?.ECDH(context: KeyContext.Identity, account: 0, change: 0, keyIndex: 0, otherPartyPub: bobKey!, meFirst: false, derivationType: BIP32DerivationType.Khovratovich)
-        let bobSharedSecret2 = bob?.ECDH(context: KeyContext.Identity, account: 0, change: 0, keyIndex: 0, otherPartyPub: aliceKey!, meFirst: true, derivationType: BIP32DerivationType.Khovratovich)
+        let aliceSharedSecret2 = try alice?.ECDH(context: KeyContext.Identity, account: 0, change: 0, keyIndex: 0, otherPartyPub: bobKey!, meFirst: false, derivationType: BIP32DerivationType.Khovratovich)
+        let bobSharedSecret2 = try bob?.ECDH(context: KeyContext.Identity, account: 0, change: 0, keyIndex: 0, otherPartyPub: aliceKey!, meFirst: true, derivationType: BIP32DerivationType.Khovratovich)
 
         XCTAssertNotEqual(aliceSharedSecret, aliceSharedSecret2)
         XCTAssertNotEqual(bobSharedSecret, bobSharedSecret2)

--- a/Tests/bip32-ed25519-swiftTests/bip32-ed25519-swiftTests.swift
+++ b/Tests/bip32-ed25519-swiftTests/bip32-ed25519-swiftTests.swift
@@ -221,14 +221,16 @@ final class Bip32Ed25519Tests: XCTestCase {
             let derivedKey = try c!.deriveChildNodePublic(
                 extendedKey: walletRoot,
                 index: UInt32(i),
-                g: BIP32DerivationType.Peikert)
+                g: BIP32DerivationType.Peikert
+            )
             // Deriving from my own wallet where i DO have private information
             let myKey = try c!.keyGen(
                 context: context,
                 account: account,
                 change: change,
                 keyIndex: UInt32(i),
-                derivationType: BIP32DerivationType.Peikert)
+                derivationType: BIP32DerivationType.Peikert
+            )
 
             // they should NOT match  since the `change` level (as part of BIP44) was hardened
             // derivedKey.prefix(32) ==  public key (excluding chaincode)
@@ -265,14 +267,16 @@ final class Bip32Ed25519Tests: XCTestCase {
         }
 
         var derivationPath: [UInt32] = [
-            c!.harden(44), c!.harden(283), c!.harden(0), 0, 0] + Array(repeating: 0, count: 19)
+            c!.harden(44), c!.harden(283), c!.harden(0), 0, 0,
+        ] + Array(repeating: 0, count: 19)
         let derivationType = BIP32DerivationType.Peikert
 
         _ = try c!.deriveKey(
             rootKey: c!.fromSeed(data),
             bip44Path: derivationPath,
             isPrivate: true,
-            derivationType: derivationType)
+            derivationType: derivationType
+        )
 
         derivationPath += [0]
 
@@ -283,8 +287,10 @@ final class Bip32Ed25519Tests: XCTestCase {
                 rootKey: c!.fromSeed(data),
                 bip44Path: derivationPath,
                 isPrivate: true,
-                derivationType: derivationType),
-                "Expected deriveKey to throw an error")
+                derivationType: derivationType
+            ),
+            "Expected deriveKey to throw an error"
+        )
     }
 
     func testKeyGeneration() throws {
@@ -318,7 +324,7 @@ final class Bip32Ed25519Tests: XCTestCase {
         ]
 
         for (input, expected) in testVectors {
-            let pk = (try c?.keyGen(context: input.0, account: input.1, change: input.2, keyIndex: input.3, derivationType: BIP32DerivationType.Khovratovich))!
+            let pk = try (c?.keyGen(context: input.0, account: input.1, change: input.2, keyIndex: input.3, derivationType: BIP32DerivationType.Khovratovich))!
             XCTAssertEqual(pk, expected)
         }
     }


### PR DESCRIPTION
- Adds a BigIntException with Overflow case, representing when the highest bit (Bit 255) gets set.
- Adds a test that confirms that there are 8 safe levels for Peikert and 67108864 for Khovratovich. The latter takes some time to execute and so is not part of the normal tests. Test works by mocking deriveChildNodePrivate, specifically changing the deriveNonHardened call to always return 32 bytes of 0xFF.
- Also adds the safe levels test for known seed, which checks that we get overflow when we go from 24->25 levels (with the first 5 conforming to the normal Bip44 and 0s).
- Since we now explicitly trigger an exception, we need to add throws and tries.