### PR TITLE
fix: open up SignMetadata

### DIFF
--- a/.github/workflows/swift-test-and-build.yaml
+++ b/.github/workflows/swift-test-and-build.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Swift
-        uses: swift-actions/setup@v2
+        uses: swift-actions/setup-swift@v2
         with:
           swift-version: "5.9"
 

--- a/Sources/x-hd-wallet-api/x-hd-wallet-api.swift
+++ b/Sources/x-hd-wallet-api/x-hd-wallet-api.swift
@@ -57,7 +57,7 @@ class DataValidationException: Error {
 public struct Schema {
     var jsonSchema: [String: Any]
 
-    init(filePath: String) throws {
+    public init(filePath: String) throws {
         let url = URL(fileURLWithPath: filePath)
         let data = try Data(contentsOf: url)
         let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])

--- a/Sources/x-hd-wallet-api/x-hd-wallet-api.swift
+++ b/Sources/x-hd-wallet-api/x-hd-wallet-api.swift
@@ -55,7 +55,7 @@ class DataValidationException: Error {
 }
 
 public struct Schema {
-    var jsonSchema: [String: Any]
+    public var jsonSchema: [String: Any]
 
     public init(filePath: String) throws {
         let url = URL(fileURLWithPath: filePath)
@@ -71,8 +71,8 @@ public struct Schema {
 }
 
 public struct SignMetadata {
-    var encoding: Encoding
-    var schema: Schema
+    public var encoding: Encoding
+    public var schema: Schema
 
     public init(encoding: Encoding, schema: Schema) {
         self.encoding = encoding

--- a/Sources/x-hd-wallet-api/x-hd-wallet-api.swift
+++ b/Sources/x-hd-wallet-api/x-hd-wallet-api.swift
@@ -73,6 +73,11 @@ public struct Schema {
 public struct SignMetadata {
     var encoding: Encoding
     var schema: Schema
+
+    public init(encoding: Encoding, schema: Schema) {
+        self.encoding = encoding
+        self.schema = schema
+    }
 }
 
 extension Data {

--- a/Tests/x-hd-wallet-apiTests/x-hd-wallet-apiTests.swift
+++ b/Tests/x-hd-wallet-apiTests/x-hd-wallet-apiTests.swift
@@ -16,9 +16,9 @@
  */
 
 import BigInt
-@testable import x_hd_wallet_api
 import MessagePack
 import MnemonicSwift
+@testable import x_hd_wallet_api
 import XCTest
 
 enum MyError: Error {


### PR DESCRIPTION
<img width="882" alt="Screenshot 2025-04-27 at 15 56 01" src="https://github.com/user-attachments/assets/1f84915e-2f53-424e-9008-534d7581a6e9" />

Seeing this error when trying to do arbitrary signing.


Edit: just to clarify. I have been trying to import this lib into liquid-auth-ios, where as part of the registration flow we need to sign an authentication challenge with an Algorand address. Unfortunately I am unable to properly call the signData method and supply SignMetaData or Schema.

Applying an extension to these in liquid-auth-ios allowed me some progress but not the full.